### PR TITLE
fix: redirect authenticated users from login to home

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -72,6 +72,9 @@ export async function middleware(request: NextRequest) {
     const path = request.nextUrl.pathname
 
     if (publicPaths.some((publicPath) => path.startsWith(publicPath))) {
+        if (user && path === '/login') {
+            return createRedirectWithCookies(request, supabaseResponse, '/')
+        }
         return supabaseResponse
     }
 


### PR DESCRIPTION
### **User description**
- Add redirection logic in `middleware.ts` to send authenticated users to `/` if they access `/login`.
- This fixes the failing E2E test `認証済みユーザーはログインページにアクセスしてもホームにリダイレクトされる`.


___

### **PR Type**
Bug fix


___

### **Description**
- Redirect authenticated users from `/login` to `/` home page

- Fixes failing E2E test for authenticated user login redirect

- Adds authentication check in public paths middleware logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Authenticated User<br/>Accesses /login"] --> B["Middleware Check<br/>Public Paths"]
  B --> C["User Exists &<br/>Path is /login"]
  C --> D["Redirect to /<br/>Home Page"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware.ts</strong><dd><code>Add authenticated user redirect from login</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/middleware.ts

<ul><li>Added authentication check in public paths section to detect <br>authenticated users accessing <code>/login</code><br> <li> Implemented redirect logic using <code>createRedirectWithCookies</code> to send <br>authenticated users to <code>/</code> instead of allowing login page access<br> <li> Preserves existing redirect behavior for unauthenticated users</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/otodoki3/pull/57/files#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

