### PR TITLE
Fix playlists E2E tests

### DIFF
--- a/e2e/playlists.spec.ts
+++ b/e2e/playlists.spec.ts
@@ -123,7 +123,11 @@ test.describe('プレイリスト画面', () => {
     });
 
     test('プレイリストから戻るボタンで一覧に戻れる', async ({ page }) => {
-        // プレイリスト詳細画面に移動
+        // プレイリスト一覧画面に移動してから詳細画面に移動（履歴を作成するため）
+        await page.goto('/playlists');
+        await page.waitForLoadState('networkidle');
+
+        // お気に入りプレイリストなどに移動
         await page.goto('/playlists/likes');
         await page.waitForLoadState('networkidle');
 

--- a/src/app/playlists/[id]/page.tsx
+++ b/src/app/playlists/[id]/page.tsx
@@ -98,6 +98,7 @@ export default function PlaylistDetailPage() {
               type="button"
               onClick={() => router.push("/playlists")}
               className="text-2xl hover:opacity-70"
+              aria-label="戻る"
             >
               ←
             </button>
@@ -115,7 +116,10 @@ export default function PlaylistDetailPage() {
         {tracks.length === 0 ? (
           <p className="text-center text-gray-400 py-8">曲がありません</p>
         ) : (
-          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          <div
+            className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
+            data-testid="track-list"
+          >
             {tracks.map((track) => (
               <button
                 key={track.track_id}

--- a/src/app/playlists/page.tsx
+++ b/src/app/playlists/page.tsx
@@ -55,6 +55,7 @@ export default function PlaylistsPage() {
             key={pl.id}
             href={`/playlists/${pl.id}`}
             className="flex items-center gap-4 p-4 bg-gray-800 rounded-lg hover:bg-gray-700"
+            data-testid="playlist-item"
           >
             <span className="text-3xl">{pl.icon}</span>
             <div className="flex-1">


### PR DESCRIPTION
### **User description**
- Fix navigation history in `playlists.spec.ts` so `goBack()` returns to the list page.
- Add `data-testid="playlist-item"` to playlist links in `src/app/playlists/page.tsx` for robust testing.
- Add `aria-label="戻る"` to back button and `data-testid="track-list"` in `src/app/playlists/[id]/page.tsx` to fix selector issues and accessibility.


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Fix E2E test navigation by establishing proper history before goBack()

- Add `data-testid="playlist-item"` to playlist links for robust selectors

- Add `data-testid="track-list"` to track grid for reliable element targeting

- Add `aria-label="戻る"` to back button for improved accessibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["E2E Test Navigation"] -->|"Establish history"| B["Visit /playlists first"]
  B -->|"Then navigate"| C["Go to /playlists/likes"]
  C -->|"Test goBack()"| D["Return to list"]
  E["Playlist Links"] -->|"Add data-testid"| F["playlist-item selector"]
  G["Track Grid"] -->|"Add data-testid"| H["track-list selector"]
  I["Back Button"] -->|"Add aria-label"| J["Accessibility improvement"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playlists.spec.ts</strong><dd><code>Fix navigation history for goBack test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/playlists.spec.ts

<ul><li>Modified test to establish navigation history by visiting <code>/playlists</code> <br>before navigating to <code>/playlists/likes</code><br> <li> Updated comment to clarify the purpose of visiting the list page first<br> <li> Ensures <code>goBack()</code> properly returns to the list page instead of exiting <br>the app</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/otodoki3/pull/59/files#diff-534eccf38e2f0a67626b788d065a9324e1cc0e8de4f00a9bac5fb24820531411">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add test selector to playlist links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/playlists/page.tsx

<ul><li>Added <code>data-testid="playlist-item"</code> attribute to the playlist Link <br>component<br> <li> Enables E2E tests to reliably select and interact with individual <br>playlist items</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/otodoki3/pull/59/files#diff-bd68a542fd6d08f25d65c5261ee36ad07e0bea38ffdf19f4231b807da1116556">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add accessibility label and test selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/playlists/[id]/page.tsx

<ul><li>Added <code>aria-label="戻る"</code> to the back button for accessibility<br> <li> Added <code>data-testid="track-list"</code> to the track grid container for E2E <br>test selection<br> <li> Improves both accessibility and test reliability for track list <br>interactions</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/otodoki3/pull/59/files#diff-eed593b68fcea5e751794fd632db1afdb15885ae1b040d9d701ad3b2c2ac31d0">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

