### PR TITLE
feat: replace random track selection with RPC call to get_random_artists

### DIFF
--- a/supabase/functions/refill-pool-artist/index.ts
+++ b/supabase/functions/refill-pool-artist/index.ts
@@ -7,6 +7,7 @@ declare const Deno: {
 
 const USER_AGENT = "otodoki3/1.0 (Supabase Edge Function)";
 const ITUNES_TIMEOUT_MS = 10000;
+const ARTIST_PICK_COUNT = 5;
 
 interface iTunesSearchResult {
     trackId: number;
@@ -145,7 +146,7 @@ Deno.serve(async (req: Request) => {
 
         // 1) Pick random tracks from pool
         const { data: randomTracks, error: randomError } = await supabase
-            .rpc('get_random_artists', { limit_count: 5 });
+            .rpc('get_random_artists', { limit_count: ARTIST_PICK_COUNT });
 
         if (randomError) throw randomError;
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replace direct database query with RPC call for random artist selection

- Simplify track pool query using `get_random_artists` stored procedure

- Remove PostgREST random ordering workaround in favor of database function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Direct DB Query<br/>order by random()"] -- "Refactored to" --> B["RPC Function Call<br/>get_random_artists"]
  B -- "Returns" --> C["Random Artists<br/>from Pool"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Replace random query with RPC call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

supabase/functions/refill-pool-artist/index.ts

<ul><li>Replaced <br><code>.from('track_pool').select('artist_name').order('random()').limit(5)</code> <br>with <code>.rpc('get_random_artists', { limit_count: 5 })</code><br> <li> Removed PostgREST random ordering workaround and associated ESLint <br>disable comment<br> <li> Simplified random track selection logic by delegating to database RPC <br>function</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/otodoki3/pull/70/files#diff-448adcca5f14b0ff2aca47376df62c6491af9e59f64e4aa9a29c97c89c2ad702">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

