### PR TITLE
Implement Last.fm track pool cleanup with error handling

### DIFF
--- a/supabase/functions/cleanup-pool/index.ts
+++ b/supabase/functions/cleanup-pool/index.ts
@@ -16,7 +16,7 @@ const LAST_FM_API_KEY = Deno.env.get('LAST_FM_API_KEY');
 
 interface TrackPoolRow {
     id: string;
-    artist: string;
+    artist_name: string;
 }
 
 interface LastFmArtistStats {
@@ -36,7 +36,7 @@ interface LastFmSearchResponse {
 }
 
 interface DeletedTrack {
-    artist: string;
+    artist_name: string;
     listeners: number;
 }
 
@@ -200,7 +200,7 @@ Deno.serve(async (req: Request) => {
                 new Promise<{ track: TrackPoolRow; listeners: number | null }>((resolve) =>
                     setTimeout(
                         () =>
-                            getLastFmListeners(track.artist)
+                            getLastFmListeners(track.artist_name)
                                 .then((listeners) => resolve({ track, listeners }))
                                 .catch(() => resolve({ track, listeners: null })),
                         index * RATE_LIMIT_DELAY_MS
@@ -222,10 +222,10 @@ Deno.serve(async (req: Request) => {
             if (listeners < LISTENERS_THRESHOLD) {
                 trackIdsToDelete.push(track.id);
                 deletedTracks.push({
-                    artist: track.artist,
+                    artist_name: track.artist_name,
                     listeners,
                 });
-                console.log(`[Deleted] ${track.artist} - listeners: ${listeners}`);
+                console.log(`[Deleted] ${track.artist_name} - listeners: ${listeners}`);
             }
         }
 

--- a/supabase/migrations/20251227000001_add_get_random_tracks_for_cleanup.sql
+++ b/supabase/migrations/20251227000001_add_get_random_tracks_for_cleanup.sql
@@ -3,14 +3,14 @@ CREATE EXTENSION IF NOT EXISTS tsm_system_rows;
 
 -- ランダムなトラックを取得するRPC関数（cleanup-pool用）
 CREATE OR REPLACE FUNCTION get_random_tracks_for_cleanup(limit_count int DEFAULT 50)
-RETURNS TABLE (id text, artist text)
+RETURNS TABLE (id uuid, artist_name text)
 LANGUAGE sql
 VOLATILE
 SECURITY DEFINER
 SET search_path = public
 AS $$
   -- limit_countのバリデーション（1〜200の範囲に制限）
-  SELECT id, artist 
+  SELECT id, artist_name 
   FROM track_pool
   TABLESAMPLE SYSTEM_ROWS(
     CASE 


### PR DESCRIPTION
### **User description**
Introduce a cron job that cleans up the track pool by filtering out tracks with listener counts below a specified threshold. Improve error response formatting in the cleanup function for better clarity.


___

### **PR Type**
Enhancement


___

### **Description**
- Implement Last.fm track pool cleanup cron job with listener filtering

- Fetch random tracks and filter by Last.fm listener count threshold

- Add timing-safe authentication and comprehensive error handling

- Include rate limiting and detailed cleanup operation logging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cron Request"] --> B["Verify Authorization"]
  B --> C["Fetch Random Tracks"]
  C --> D["Query Last.fm API"]
  D --> E["Filter by Listener Count"]
  E --> F["Delete Low-Listener Tracks"]
  F --> G["Return Cleanup Report"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Last.fm track pool cleanup cron job implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

supabase/functions/cleanup-pool/index.ts

<ul><li>Create new Supabase Edge Function for track pool cleanup with Last.fm <br>integration<br> <li> Implement timing-safe authentication using Bearer token comparison<br> <li> Fetch random 50 tracks and query Last.fm API for listener counts<br> <li> Delete tracks with listener count below 10,000 threshold<br> <li> Add rate limiting (200ms delay), timeout handling, and comprehensive <br>error logging</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/otodoki3/pull/75/files#diff-d2c57688ba706c163ad16aa8600d3b44a7597e74be20139a8e7c8464d3f3b157">+251/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

