### PR TITLE
Streamline Supabase project linking and simplify migration commands

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -39,6 +39,7 @@ jobs:
         run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF_TEST }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD_TEST }}
 
       - name: Apply Migrations to Test
         run: |
@@ -46,6 +47,7 @@ jobs:
           supabase db push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD_TEST }}
 
       - name: Deploy all Edge Functions to Test
         run: |
@@ -112,6 +114,7 @@ jobs:
         run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       - name: Apply Migrations to Production
         run: |
@@ -119,6 +122,7 @@ jobs:
           supabase db push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       - name: Deploy all Edge Functions to Production
         run: |


### PR DESCRIPTION
### **User description**
Enhance the deployment workflow by linking Supabase projects directly in the commands and removing redundant project references in migration commands. This simplifies the process for both test and production environments.


___

### **PR Type**
Enhancement


___

### **Description**
- Add explicit Supabase project linking steps for test and production environments

- Remove redundant `--project-ref` flags from migration commands

- Simplify migration commands by relying on linked project context


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Setup Supabase CLI"] --> B["Link Supabase Project"]
  B --> C["Apply Migrations"]
  C --> D["Deploy Edge Functions"]
  style B fill:#90EE90
  style C fill:#87CEEB
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-supabase.yml</strong><dd><code>Refactor Supabase linking and simplify migration commands</code></dd></summary>
<hr>

.github/workflows/deploy-supabase.yml

<ul><li>Added new "Link Supabase Project" steps for both test and production <br>jobs<br> <li> Removed <code>--project-ref</code> parameter from <code>supabase db push</code> commands in test <br>environment<br> <li> Removed <code>--project-ref</code> parameter from <code>supabase db push</code> commands in <br>production environment<br> <li> Streamlined migration workflow by establishing project context upfront</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/otodoki3/pull/79/files#diff-48576549c894489de9776af29949684cd67a6f9eb337c1fb5a14a44b68d45af0">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

