### PR TITLE
fix: CI環境でのPlaywrightテストのために既存サーバーの再利用を無効化

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
     webServer: {
         command: 'npm run dev',
         url: 'http://localhost:3000',
-        reuseExistingServer: !process.env.CI,
+        reuseExistingServer: false,
         env: {
             NEXT_PUBLIC_SUPABASE_URL,
             NEXT_PUBLIC_SUPABASE_ANON_KEY,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Disable server reuse in Playwright tests for CI environments

- Change `reuseExistingServer` from conditional to always false

- Ensures fresh server instance for each test run in CI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["playwright.config.ts"] -- "reuseExistingServer: !process.env.CI" --> B["Old: Conditional reuse"]
  A -- "reuseExistingServer: false" --> C["New: Always disabled"]
  C -- "Ensures fresh server" --> D["Stable CI tests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playwright.config.ts</strong><dd><code>Disable server reuse in Playwright config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playwright.config.ts

<ul><li>Changed <code>reuseExistingServer</code> from <code>!process.env.CI</code> to <code>false</code><br> <li> Disables server reuse unconditionally for all environments<br> <li> Ensures fresh server instance on each test run</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/otodoki3/pull/89/files#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

